### PR TITLE
[WIP] Use Service Workers API Prototype for registering the SW.

### DIFF
--- a/3rd-party/onesignal.php
+++ b/3rd-party/onesignal.php
@@ -19,20 +19,20 @@ if ( ! defined('ABSPATH') ) exit;
 
 // If OneSignal is installed and active
 if ( class_exists( 'OneSignal' ) ) {
-	
+
 	// Filter manifest and service worker for singe websites and not for multisites.
 	if ( ! is_multisite() ) {
-	
+
 		// Add gcm_sender_id to SuperPWA manifest
-		add_filter( 'superpwa_manifest', 'superpwa_onesignal_add_gcm_sender_id' );
-		
+		add_filter( 'web_app_manifest', 'superpwa_onesignal_add_gcm_sender_id' );
+
 		// Change service worker filename to match OneSignal's service worker
 		add_filter( 'superpwa_sw_filename', 'superpwa_onesignal_sw_filename' );
-		
+
 		// Import OneSignal service worker in SuperPWA
 		add_filter( 'superpwa_sw_template', 'superpwa_onesignal_sw' );
 	}
-	
+
 	// Show admin notice.
 	add_action( 'admin_notices', 'superpwa_onesignal_admin_notices', 9 );
 	add_action( 'network_admin_notices', 'superpwa_onesignal_admin_notices', 9 );
@@ -77,55 +77,55 @@ function superpwa_onesignal_sw_filename( $sw_filename ) {
 
 /**
  * Import OneSignal service worker in SuperPWA
- * 
+ *
  * @param (string) $sw Service worker template of SuperPWA passed via superpwa_sw_template filter
- * 
- * @return (string) Import OneSignal's service worker into SuperPWA 
- * 
+ *
+ * @return (string) Import OneSignal's service worker into SuperPWA
+ *
  * @since 1.8
  */
 function superpwa_onesignal_sw( $sw ) {
-	
-	$onesignal  = '<?php' . PHP_EOL; 
+
+	$onesignal  = '<?php' . PHP_EOL;
 	$onesignal .= 'header( "Content-Type: application/javascript" );' . PHP_EOL;
 	$onesignal .= 'echo "importScripts( \'' . superpwa_httpsify( plugin_dir_url( 'onesignal-free-web-push-notifications/onesignal.php' ) ) . 'sdk_files/OneSignalSDKWorker.js.php\' );";' . PHP_EOL;
 	$onesignal .= '?>' . PHP_EOL . PHP_EOL;
-	
+
 	return $onesignal . $sw;
 }
 
 /**
  * OneSignal activation todo
- * 
+ *
  * Regenerates SuperPWA manifest with the gcm_sender_id added.
  * Delete current service worker.
  * Regenerate SuperPWA service worker with the new filename.
- * 
+ *
  * @since 1.8
- * @since 1.8.1 Excluded multisites. No OneSignal compatibility on multisites yet. In 1.8 onesignal.php was not loaded for multisites. 
+ * @since 1.8.1 Excluded multisites. No OneSignal compatibility on multisites yet. In 1.8 onesignal.php was not loaded for multisites.
  */
 function superpwa_onesignal_activation() {
-	
+
 	// Do not do anything for multisites
 	if ( is_multisite() ) {
 		return;
 	}
-	
+
 	// Filter in gcm_sender_id to SuperPWA manifest
-	add_filter( 'superpwa_manifest', 'superpwa_onesignal_add_gcm_sender_id' );
-	
+	add_filter( 'web_app_manifest', 'superpwa_onesignal_add_gcm_sender_id' );
+
 	// Regenerate SuperPWA manifest
 	superpwa_generate_manifest();
-	
+
 	// Delete service worker if it exists
 	superpwa_delete_sw();
-	
+
 	// Change service worker filename to match OneSignal's service worker
 	add_filter( 'superpwa_sw_filename', 'superpwa_onesignal_sw_filename' );
-	
+
 	// Import OneSignal service worker in SuperPWA
 	add_filter( 'superpwa_sw_template', 'superpwa_onesignal_sw' );
-	
+
 	// Regenerate SuperPWA service worker
 	superpwa_generate_sw();
 }
@@ -133,36 +133,36 @@ add_action( 'activate_onesignal-free-web-push-notifications/onesignal.php', 'sup
 
 /**
  * OneSignal deactivation todo
- * 
+ *
  * Regenerates SuperPWA manifest.
- * Delete current service worker. 
+ * Delete current service worker.
  * Regenerate SuperPWA service worker.
- * 
+ *
  * @since 1.8
- * @since 1.8.1 Excluded multisites. No OneSignal compatibility on multisites yet. In 1.8 onesignal.php was not loaded for multisites. 
+ * @since 1.8.1 Excluded multisites. No OneSignal compatibility on multisites yet. In 1.8 onesignal.php was not loaded for multisites.
  */
 function superpwa_onesignal_deactivation() {
-	
+
 	// Do not do anything for multisites
 	if ( is_multisite() ) {
 		return;
 	}
-	
+
 	// Remove gcm_sender_id from SuperPWA manifest
-	remove_filter( 'superpwa_manifest', 'superpwa_onesignal_add_gcm_sender_id' );
-	
+	remove_filter( 'web_app_manifest', 'superpwa_onesignal_add_gcm_sender_id' );
+
 	// Regenerate SuperPWA manifest
 	superpwa_generate_manifest();
-	
+
 	// Delete service worker if it exists
 	superpwa_delete_sw();
-	
+
 	// Restore the default service worker of SuperPWA
 	remove_filter( 'superpwa_sw_filename', 'superpwa_onesignal_sw_filename' );
-	
+
 	// Remove OneSignal service worker in SuperPWA
 	remove_filter( 'superpwa_sw_template', 'superpwa_onesignal_sw' );
-	
+
 	// Regenerate SuperPWA service worker
 	superpwa_generate_sw();
 }

--- a/3rd-party/onesignal.php
+++ b/3rd-party/onesignal.php
@@ -5,7 +5,7 @@
  * @link https://wordpress.org/plugins/onesignal-free-web-push-notifications/
  *
  * @since 1.6
- * 
+ *
  * @function	superpwa_onesignal_add_gcm_sender_id()			Add gcm_sender_id to SuperPWA manifest
  * @function	superpwa_onesignal_sw_filename()				Change Service Worker filename to OneSignalSDKWorker.js.php
  * @function 	superpwa_onesignal_sw() 						Import OneSignal service worker in SuperPWA
@@ -166,52 +166,55 @@ add_action( 'deactivate_onesignal-free-web-push-notifications/onesignal.php', 's
 
 /**
  * Admin notices for OneSignal compatibility
- * 
+ *
  * One Single installs, warn users to add SuperPWA manifest as custom manifest in OneSignal settings.
- * One multisites, warn users that SuperPWA and OneSignal cannot work together. 
- * 
+ * One multisites, warn users that SuperPWA and OneSignal cannot work together.
+ *
  * @since 1.8.1
  */
 function superpwa_onesignal_admin_notices() {
-	
+
 	// Notices only for admins.
 	if ( ! current_user_can( 'manage_options' ) ) {
 		return;
 	}
-	
+
 	// Incompatibility notice for Multisites
 	if ( is_multisite() ) {
-		echo '<div class="notice notice-warning"><p>' . 
-		sprintf( 
-			__( '<strong>SuperPWA</strong> is not compatible with OneSignal on multisites yet. Disable one of these plugins until the compatibility is available.<br>Please refer to the <a href="%s" target="_blank">OneSignal integration documentation</a> for more info. ', 'super-progressive-web-apps' ), 
+		echo '<div class="notice notice-warning"><p>' .
+		sprintf(
+			__( '<strong>SuperPWA</strong> is not compatible with OneSignal on multisites yet. Disable one of these plugins until the compatibility is available.<br>Please refer to the <a href="%s" target="_blank">OneSignal integration documentation</a> for more info. ', 'super-progressive-web-apps' ),
 			'https://superpwa.com/doc/setup-onesignal-with-superpwa/?utm_source=superpwa-plugin&utm_medium=onesignal-multisite-admin-notice#multisites'
 		) . '</p></div>';
-		
-		// Filter PWA status since PWA is not ready yet. 
+
+		// Filter PWA status since PWA is not ready yet.
 		add_filter( 'superpwa_is_pwa_ready', '__return_false' );
-		
+
 		return;
 	}
-	
+
+	// @todo Return temporarily here since the manifest file is created by the SW API Prototype.
+	return;
+
 	// Get OneSignal settings.
 	$onesignal_wp_settings = get_option( 'OneSignalWPSetting' );
-	
+
 	// Show notice if OneSignal custom manifest is disabled or if the custom manifest is not the SuperPWA manifest.
-	if ( 
-		! isset( $onesignal_wp_settings['use_custom_manifest'] ) 			|| 
+	if (
+		! isset( $onesignal_wp_settings['use_custom_manifest'] ) 			||
 		! ( (int) $onesignal_wp_settings['use_custom_manifest'] === 1 )		||
-		! isset( $onesignal_wp_settings['custom_manifest_url'] ) 			|| 
+		! isset( $onesignal_wp_settings['custom_manifest_url'] ) 			||
 		! ( strcasecmp( trim( $onesignal_wp_settings['custom_manifest_url'] ), superpwa_manifest( 'src' ) ) === 0  )
 	) {
-		echo '<div class="notice notice-warning"><p>' . 
-		sprintf( 
-			__( '<strong>Action Required to integrate SuperPWA with OneSignal:</strong><br>1. Go to <a href="%s" target="_blank">OneSignal Configuration > Scroll down to Advanced Settings &rarr;</a><br>2. Enable <strong>Use my own manifest.json</strong><br>3. Set <code>%s</code>as <strong>Custom manifest.json URL</strong> and Save Settings.<br>Please refer the <a href="%s" target="_blank">OneSignal integration documentation</a> for more info. ', 'super-progressive-web-apps' ), 
-			admin_url( 'admin.php?page=onesignal-push#configuration' ), 
+		echo '<div class="notice notice-warning"><p>' .
+		sprintf(
+			__( '<strong>Action Required to integrate SuperPWA with OneSignal:</strong><br>1. Go to <a href="%s" target="_blank">OneSignal Configuration > Scroll down to Advanced Settings &rarr;</a><br>2. Enable <strong>Use my own manifest.json</strong><br>3. Set <code>%s</code>as <strong>Custom manifest.json URL</strong> and Save Settings.<br>Please refer the <a href="%s" target="_blank">OneSignal integration documentation</a> for more info. ', 'super-progressive-web-apps' ),
+			admin_url( 'admin.php?page=onesignal-push#configuration' ),
 			superpwa_manifest( 'src' ),
 			'https://superpwa.com/doc/setup-onesignal-with-superpwa/?utm_source=superpwa-plugin&utm_medium=onesignal-admin-notice'
 		) . '</p></div>';
-		
-		// Filter PWA status since PWA is not ready yet. 
+
+		// Filter PWA status since PWA is not ready yet.
 		add_filter( 'superpwa_is_pwa_ready', '__return_false' );
 	}
 }

--- a/3rd-party/onesignal.php
+++ b/3rd-party/onesignal.php
@@ -44,35 +44,35 @@ if ( class_exists( 'OneSignal' ) ) {
  * OneSignal's gcm_sender_id is 482941778795
  *
  * @param (array) $manifest Array with the manifest entries passed via the superpwa_manifest filter.
- * 
+ *
  * @return (array) Array appended with the gcm_sender_id of OneSignal
- * 
+ *
  * @since 1.8
  */
 function superpwa_onesignal_add_gcm_sender_id( $manifest ) {
-	
+
 	$manifest['gcm_sender_id'] = '482941778795';
-	
+
 	return $manifest;
 }
 
 /**
  * Change Service Worker filename to OneSignalSDKWorker.js.php
- * 
+ *
  * OneSignalSDKWorker.js.php is the name of the service worker of OneSignal.
- * Since only one service worker is allowed in a given scope, OneSignal unregisters all other service workers and registers theirs. 
- * Having the same name prevents OneSignal from unregistering our service worker. 
- * 
+ * Since only one service worker is allowed in a given scope, OneSignal unregisters all other service workers and registers theirs.
+ * Having the same name prevents OneSignal from unregistering our service worker.
+ *
  * @link https://documentation.onesignal.com/docs/web-push-setup-faq
- * 
+ *
  * @param (string) $sw_filename Filename of SuperPWA service worker passed via superpwa_sw_filename filter.
- * 
+ *
  * @return (string) Service worker filename changed to OneSignalSDKWorker.js.php
- * 
+ *
  * @since 1.8
  */
 function superpwa_onesignal_sw_filename( $sw_filename ) {
-	return 'OneSignalSDKWorker.js.php';
+	return 'OneSignalSDKWorker.js';
 }
 
 /**
@@ -86,11 +86,7 @@ function superpwa_onesignal_sw_filename( $sw_filename ) {
  */
 function superpwa_onesignal_sw( $sw ) {
 
-	$onesignal  = '<?php' . PHP_EOL;
-	$onesignal .= 'header( "Content-Type: application/javascript" );' . PHP_EOL;
-	$onesignal .= 'echo "importScripts( \'' . superpwa_httpsify( plugin_dir_url( 'onesignal-free-web-push-notifications/onesignal.php' ) ) . 'sdk_files/OneSignalSDKWorker.js.php\' );";' . PHP_EOL;
-	$onesignal .= '?>' . PHP_EOL . PHP_EOL;
-
+	$onesignal = "importScripts( '" . superpwa_httpsify( plugin_dir_url( 'onesignal-free-web-push-notifications/onesignal.php' ) ) . "sdk_files/OneSignalSDKWorker.js.php' );";
 	return $onesignal . $sw;
 }
 

--- a/public/manifest.php
+++ b/public/manifest.php
@@ -68,19 +68,22 @@ function superpwa_manifest( $arg = 'src' ) {
  * @since 1.8 Removed gcm_sender_id and introduced filter superpwa_manifest. gcm_sender_id is added in /3rd-party/onesignal.php
  */
 function superpwa_generate_manifest() {
-	
+
+	// @todo Temporarily removed manifest generation since SW API Prototype already generates the manifest.
+	return true;
+
 	// Get Settings
 	$settings = superpwa_get_settings();
-	
+
 	$manifest 						= array();
 	$manifest['name']				= $settings['app_name'];
 	$manifest['short_name']			= $settings['app_short_name'];
-	
+
 	// Description
 	if ( isset( $settings['description'] ) && ! empty( $settings['description'] ) ) {
 		$manifest['description'] 	= $settings['description'];
 	}
-	
+
 	$manifest['icons']				= superpwa_get_pwa_icons();
 	$manifest['background_color']	= $settings['background_color'];
 	$manifest['theme_color']		= $settings['theme_color'];

--- a/public/sw.php
+++ b/public/sw.php
@@ -204,27 +204,11 @@ function checkNeverCacheList(url) {
  */
 function superpwa_register_sw() {
 
-	if ( ! class_exists( 'OneSignal' ) && function_exists( 'wp_register_service_worker' ) ) {
+	if ( function_exists( 'wp_register_service_worker' ) ) {
 		wp_register_service_worker( 'superpwa-sw', superpwa_sw( 'src' ) );
 	}
 }
 add_action( 'plugins_loaded', 'superpwa_register_sw' );
-
-/**
- * Register SW separately in case of OneSignal.
- */
-function superpwa_register_onesignal_sw() {
-
-	// If OneSignal is installed and active.
-	if ( class_exists( 'OneSignal' ) ) {
-		wp_enqueue_script( 'superpwa-register-sw', SUPERPWA_PATH_SRC . 'public/js/register-sw.js', array(), null, true );
-		wp_localize_script( 'superpwa-register-sw', 'superpwa_sw', array(
-				'url' => superpwa_sw( 'src' ),
-			)
-		);
-	}
-}
-add_action( 'wp_enqueue_scripts', 'superpwa_register_onesignal_sw' );
 
 /**
  * Delete Service Worker

--- a/public/sw.php
+++ b/public/sw.php
@@ -3,7 +3,7 @@
  * Service worker related functions of SuperPWA
  *
  * @since 1.0
- * 
+ *
  * @function	superpwa_sw()				Service worker filename, absolute path and link
  * @function	superpwa_generate_sw()		Generate and write service worker into sw.js
  * @function	superpwa_sw_template()		Service worker tempalte
@@ -25,31 +25,31 @@ if ( ! defined( 'ABSPATH' ) ) exit;
  *				src for relative link to service worker (replaces SUPERPWA_SW_SRC). Default value
  *
  * @return (string) filename, absolute path or link to manifest.
- * 
+ *
  * @since 1.6
  * @since 1.7 src to service worker is made relative to accomodate for domain mapped multisites.
  * @since 1.8 Added filter superpwa_sw_filename.
  */
 function superpwa_sw( $arg = 'src' ) {
-	
+
 	$sw_filename = apply_filters( 'superpwa_sw_filename', 'superpwa-sw' . superpwa_multisite_filename_postfix() . '.js' );
-	
+
 	switch( $arg ) {
-		
+
 		// Name of service worker file
 		case 'filename':
 			return $sw_filename;
 			break;
-		
-		// Absolute path to service worker. SW must be in the root folder	
+
+		// Absolute path to service worker. SW must be in the root folder
 		case 'abs':
-			return trailingslashit( ABSPATH ) . $sw_filename;
+			return trailingslashit( SUPERPWA_PATH_ABS ) . $sw_filename;
 			break;
-		
+
 		// Link to service worker
 		case 'src':
 		default:
-			return parse_url( trailingslashit( network_site_url() ) . $sw_filename, PHP_URL_PATH );
+			return parse_url( trailingslashit( SUPERPWA_PATH_SRC ) . $sw_filename, PHP_URL_PATH );
 			break;
 	}
 }
@@ -58,24 +58,24 @@ function superpwa_sw( $arg = 'src' ) {
  * Generate and write service worker into superpwa-sw.js
  *
  * @return (boolean) true on success, false on failure.
- * 
+ *
  * @since 1.0
  */
 function superpwa_generate_sw() {
-	
+
 	// Get Settings
 	$settings = superpwa_get_settings();
-	
+
 	// Get the service worker tempalte
 	$sw = superpwa_sw_template();
-	
+
 	// Delete service worker if it exists
 	superpwa_delete_sw();
-	
+
 	if ( ! superpwa_put_contents( superpwa_sw( 'abs' ), $sw ) ) {
 		return false;
 	}
-	
+
 	return true;
 }
 
@@ -83,15 +83,15 @@ function superpwa_generate_sw() {
  * Service Worker Tempalte
  *
  * @return (string) Contents to be written to superpwa-sw.js
- * 
+ *
  * @since 1.0
  * @since 1.7 added filter superpwa_sw_template
  */
 function superpwa_sw_template() {
-	
+
 	// Get Settings
 	$settings = superpwa_get_settings();
-	
+
 	// Start output buffer. Everything from here till ob_get_clean() is returned
 	ob_start();  ?>
 'use strict';
@@ -100,7 +100,7 @@ function superpwa_sw_template() {
  * Service Worker of SuperPWA
  * To learn more and add one to your website, visit - https://superpwa.com
  */
- 
+
 const cacheName = '<?php echo parse_url( get_bloginfo( 'wpurl' ), PHP_URL_HOST ) . '-superpwa-' . SUPERPWA_VERSION; ?>';
 const startPage = '<?php echo superpwa_get_start_url(); ?>';
 const offlinePage = '<?php echo get_permalink( $settings['offline_page'] ) ? superpwa_httpsify( get_permalink( $settings['offline_page'] ) ) : superpwa_httpsify( get_bloginfo( 'wpurl' ) ); ?>';
@@ -137,21 +137,21 @@ self.addEventListener('activate', function(e) {
 
 // Fetch
 self.addEventListener('fetch', function(e) {
-	
+
 	// Return if the current request url is in the never cache list
 	if ( ! neverCacheUrls.every(checkNeverCacheList, e.request.url) ) {
 	  console.log( 'SuperPWA: Current request is excluded from cache.' );
 	  return;
 	}
-	
+
 	// Return if request url protocal isn't http or https
 	if ( ! e.request.url.match(/^(http|https):\/\//i) )
 		return;
-	
+
 	// Return if request url is from an external domain.
 	if ( new URL(e.request.url).origin !== location.origin )
 		return;
-	
+
 	// For POST requests, do not use the cache. Serve offline page if offline.
 	if ( e.request.method !== 'GET' ) {
 		e.respondWith(
@@ -161,7 +161,7 @@ self.addEventListener('fetch', function(e) {
 		);
 		return;
 	}
-	
+
 	// Revving strategy
 	if ( e.request.mode === 'navigate' && navigator.onLine ) {
 		e.respondWith(
@@ -169,7 +169,7 @@ self.addEventListener('fetch', function(e) {
 				return caches.open(cacheName).then(function(cache) {
 					cache.put(e.request, response.clone());
 					return response;
-				});  
+				});
 			})
 		);
 		return;
@@ -181,7 +181,7 @@ self.addEventListener('fetch', function(e) {
 				return caches.open(cacheName).then(function(cache) {
 					cache.put(e.request, response.clone());
 					return response;
-				});  
+				});
 			});
 		}).catch(function() {
 			return caches.match(offlinePage);
@@ -201,26 +201,20 @@ function checkNeverCacheList(url) {
 
 /**
  * Register service worker
- *
- * @refer https://developers.google.com/web/fundamentals/primers/service-workers/registration#conclusion
- * 
- * @since 1.0
  */
 function superpwa_register_sw() {
-	
-	wp_enqueue_script( 'superpwa-register-sw', SUPERPWA_PATH_SRC . 'public/js/register-sw.js', array(), null, true );
-	wp_localize_script( 'superpwa-register-sw', 'superpwa_sw', array(
-			'url' => superpwa_sw( 'src' ),
-		)
-	);
+
+	if ( function_exists( 'wp_register_service_worker' ) ) {
+		wp_register_service_worker( 'superpwa-sw', superpwa_sw( 'src' ) );
+	}
 }
-add_action( 'wp_enqueue_scripts', 'superpwa_register_sw' );
+add_action( 'plugins_loaded', 'superpwa_register_sw' );
 
 /**
  * Delete Service Worker
  *
  * @return true on success, false on failure
- * 
+ *
  * @since 1.0
  */
 function superpwa_delete_sw() {

--- a/public/sw.php
+++ b/public/sw.php
@@ -200,15 +200,31 @@ function checkNeverCacheList(url) {
 }
 
 /**
- * Register service worker
+ * Register service worker.
  */
 function superpwa_register_sw() {
 
-	if ( function_exists( 'wp_register_service_worker' ) ) {
+	if ( ! class_exists( 'OneSignal' ) && function_exists( 'wp_register_service_worker' ) ) {
 		wp_register_service_worker( 'superpwa-sw', superpwa_sw( 'src' ) );
 	}
 }
 add_action( 'plugins_loaded', 'superpwa_register_sw' );
+
+/**
+ * Register SW separately in case of OneSignal.
+ */
+function superpwa_register_onesignal_sw() {
+
+	// If OneSignal is installed and active.
+	if ( class_exists( 'OneSignal' ) ) {
+		wp_enqueue_script( 'superpwa-register-sw', SUPERPWA_PATH_SRC . 'public/js/register-sw.js', array(), null, true );
+		wp_localize_script( 'superpwa-register-sw', 'superpwa_sw', array(
+				'url' => superpwa_sw( 'src' ),
+			)
+		);
+	}
+}
+add_action( 'wp_enqueue_scripts', 'superpwa_register_onesignal_sw' );
 
 /**
  * Delete Service Worker


### PR DESCRIPTION
Replaces registering the service worker logic by using `wp_register_service_worker`.
Also disables creating a custom manifest and uses the manifest of [PWA WP](https://github.com/xwp/pwa-wp) plugin instead.

Note that this PR does not completely remove the logic and files that are unnecessary with using the new prototype API, it just disables it.

Todo:
- Perhaps require the pwa-wp plugin being installed and active;